### PR TITLE
Specify version number manually so node.inflections can run in the browser

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -590,10 +590,7 @@
 /**
  * @public
  */
-  inflector.version = JSON.parse(
-    require( 'fs' ).readFileSync( __dirname + '/../package.json', 'utf8' )
-  ).version;
-
+  inflector.version = "1.2.5";
 /**
  * Exports module.
  */


### PR DESCRIPTION
While less dry, this patch removes the FS dependency so inflections can be used in the browser (via browserify, for example).
