### PR TITLE
Error "TypeError: Object # has no method '_apply_rules'"

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -246,7 +246,7 @@
    *     inflection.pluralize( 'person', 'guys' ); // === 'guys'
    */
     pluralize : function ( str, plural ){
-      return this._apply_rules( str, plural_rules, uncountable_words, plural );
+      return inflector._apply_rules( str, plural_rules, uncountable_words, plural );
     },
 
 
@@ -268,7 +268,7 @@
    *     inflection.singularize( 'guys', 'person' ); // === 'person'
    */
     singularize : function ( str, singular ){
-      return this._apply_rules( str, singular_rules, uncountable_words, singular );
+      return inflector._apply_rules( str, singular_rules, uncountable_words, singular );
     },
 
 


### PR DESCRIPTION
Doesn't seem to work en Node 0.8.9 . 
Error "TypeError: Object # has no method '_apply_rules'"

In inflection.js, I replaced where it appears "this._apply_rules" with "inflector._apply_rules" and seems to work properly.
