### PR TITLE
Fix the lower case first letter for first word

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -293,20 +293,20 @@
       var str_path = str.split( '/' );
       var i        = 0;
       var j        = str_path.length;
-      var str_arr, init_x, k, l;
+      var str_arr, init_x, k, l, first;
 
       for( ; i < j; i++ ){
         str_arr = str_path[ i ].split( '_' );
-        init_x  = (( lowFirstLetter && i + 1 === j ) ? ( 1 ) : ( 0 ));
-        k       = init_x;
+        k       = 0;
         l       = str_arr.length;
 
         for( ; k < l; k++ ){
-          if( k !== 0 ){
+          if(k !== 0) {
             str_arr[ k ] = str_arr[ k ].toLowerCase();
           }
-
-          str_arr[ k ] = str_arr[ k ].charAt( 0 ).toUpperCase() + str_arr[ k ].substring( 1 );
+          first = str_arr[ k ].charAt( 0 );
+          first = lowFirstLetter && i === 0 && k === 0 ? first.toLowerCase() : first.toUpperCase();          
+          str_arr[ k ] = first + str_arr[ k ].substring( 1 );
         }
 
         str_path[ i ] = str_arr.join( '' );

--- a/test/inflection.js
+++ b/test/inflection.js
@@ -41,7 +41,15 @@ module.exports = {
     inflection.camelize( 'message_properties' ).should.equal( 'MessageProperties' );
     inflection.camelize( 'Message_Properties' ).should.equal( 'MessageProperties' );
     inflection.camelize( 'MESSAGE_PROPERTIES' ).should.equal( 'MESSAGEProperties' );
+    inflection.camelize( 'MESSAGE_PROPERTIES', true ).should.equal( 'mESSAGEProperties' );
     inflection.camelize( 'fooBar_Baz', true ).should.equal( 'fooBarBaz' );
+    inflection.camelize( 'FooBar_Baz', true ).should.equal( 'fooBarBaz' );
+    inflection.camelize( 'fooBar_fooBaz', true ).should.equal( 'fooBarFoobaz' );
+    inflection.camelize( 'FooBar_FooBaz', true ).should.equal( 'fooBarFoobaz' );
+    inflection.camelize( 'FooBar' ).should.equal( 'FooBar' );
+    inflection.camelize( 'FooBar', true ).should.equal( 'fooBar' );
+    inflection.camelize( 'Foo/Bar', true ).should.equal( 'foo::Bar' );
+    inflection.camelize( 'Foo/Bar' ).should.equal( 'Foo::Bar' );
     callback();
   },
 


### PR DESCRIPTION
The PR fixes the handling of 'lowFirstLetter' to make it consistent with http://api.rubyonrails.org/classes/String.html#method-i-camelize. 

For example,

camelize('FooBar', true); ==> 'FooBar' (before fix)
camelize('FooBar', true); ==> 'fooBar' (after fix)
