### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,7 @@
     "url" : "https://github.com/dreamerslab/node.inflection.git"
   },
   "engines" : [ "node >= 0.4.0" ],
-  "licenses": [{
-    "type": "MIT",
-    "url" : "http://en.wikipedia.org/wiki/MIT_License"
-  }],
+  "license": "MIT",
   "scripts": {
     "test" : "mocha -R spec"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/