### PR TITLE
"Real estate" plural form

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -242,6 +242,7 @@
 
     'racism',
     // 'rain',
+    'real estate',
     // 'recreation',
     'relaxation',
     'reliability',

--- a/test/inflection.js
+++ b/test/inflection.js
@@ -55,6 +55,7 @@ describe( 'test .pluralize', function (){
     inflection.pluralize( 'criteria' ).should.equal( 'criteria' );
     inflection.pluralize( 'genus' ).should.equal( 'genera' );
     inflection.pluralize( 'genera' ).should.equal( 'genera' );
+    inflection.pluralize( 'real estate' ).should.equal( 'real estate' );
   });
 });
 


### PR DESCRIPTION
"Real estate" [should be uncountable]((https://en.wiktionary.org/wiki/real_estate). Currently pluralizes to "real estates."