### PR TITLE
feat: support CamelCase to kebab-case conversion

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -960,6 +960,26 @@
     },
 
 
+    /**
+   * This function adds kebabize support to every String object.
+   * @public
+   * @function
+   * @param {String} str The subject string.
+   * @returns {String} Return camel cased words into kebab-case form.
+   * @example
+   *
+   *     var inflection = require( 'inflection' );
+   *
+   *     inflection.kebabize( 'MessageBusProperty' ); // === 'message-bus-property'
+   */
+  kebabize : function ( str ){
+    str = inflector.underscore( str );
+    str = inflector.dasherize( str );
+
+    return str;
+  },
+
+
 
   /**
    * This function adds classification support to every String object.

--- a/test/inflection.js
+++ b/test/inflection.js
@@ -213,6 +213,13 @@ describe( 'test .tableize', function (){
   });
 });
 
+describe( 'test .kebabize', function (){
+  it( 'should kebabize the given word', function (){
+    inflection.kebabize( 'people' ).should.equal( 'people' );
+    inflection.kebabize( 'MessageBusProperty' ).should.equal( 'message-bus-property' );
+  });
+});
+
 describe( 'test .classify', function (){
   it( 'should classify the given word', function (){
     inflection.classify( 'message_bus_properties' ).should.equal( 'MessageBusProperty' );


### PR DESCRIPTION
Searched for CamelCase to dash-case and didn't find it, so I added this ability to this repo.

Before:
`inflection.transform( 'AllJobs', [ 'underscore', 'dasherize' ]); // === 'all-jobs'`

Now: 
`inflection.kebabize('AllJobs'); // === all-jobs`
