### PR TITLE
Use correct pluralization for octopus and virus

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -367,7 +367,7 @@
       oes       : new RegExp( '(o)es$'                         , 'gi' ),
       shoes     : new RegExp( '(shoe)s$'                       , 'gi' ),
       crises    : new RegExp( '(cris|ax|test)es$'              , 'gi' ),
-      octopi    : new RegExp( '(octop|vir)i$'                  , 'gi' ),
+      octopuses : new RegExp( '(octop|vir)uses$'               , 'gi' ),
       aliases   : new RegExp( '(alias|canvas|status|campus)es$', 'gi' ),
       summonses : new RegExp( '^(summons)es$'                  , 'gi' ),
       oxen      : new RegExp( '^(ox)en'                        , 'gi' ),
@@ -437,7 +437,7 @@
     [ regex.plural.oes       ],
     [ regex.plural.shoes     ],
     [ regex.plural.crises    ],
-    [ regex.plural.octopi    ],
+    [ regex.plural.octopuses ],
     [ regex.plural.aliases   ],
     [ regex.plural.summonses ],
     [ regex.plural.oxen      ],
@@ -456,7 +456,7 @@
     [ regex.singular.child    , '$1ren' ],
     [ regex.singular.ox       , '$1en' ],
     [ regex.singular.axis     , '$1es' ],
-    [ regex.singular.octopus  , '$1i' ],
+    [ regex.singular.octopus  , '$1uses' ],
     [ regex.singular.alias    , '$1es' ],
     [ regex.singular.summons  , '$1es' ],
     [ regex.singular.bus      , '$1ses' ],
@@ -537,7 +537,7 @@
     [ regex.plural.oes      , '$1' ],
     [ regex.plural.shoes    , '$1' ],
     [ regex.plural.crises   , '$1is' ],
-    [ regex.plural.octopi   , '$1us' ],
+    [ regex.plural.octopuses, '$1us' ],
     [ regex.plural.aliases  , '$1' ],
     [ regex.plural.summonses, '$1' ],
     [ regex.plural.oxen     , '$1' ],
@@ -662,7 +662,7 @@
    *     var inflection = require( 'inflection' );
    *
    *     inflection.pluralize( 'person' ); // === 'people'
-   *     inflection.pluralize( 'octopus' ); // === 'octopi'
+   *     inflection.pluralize( 'octopus' ); // === 'octopuses'
    *     inflection.pluralize( 'Hat' ); // === 'Hats'
    *     inflection.pluralize( 'person', 'guys' ); // === 'guys'
    */
@@ -684,7 +684,7 @@
    *     var inflection = require( 'inflection' );
    *
    *     inflection.singularize( 'people' ); // === 'person'
-   *     inflection.singularize( 'octopi' ); // === 'octopus'
+   *     inflection.singularize( 'octopuses' ); // === 'octopus'
    *     inflection.singularize( 'Hats' ); // === 'Hat'
    *     inflection.singularize( 'guys', 'person' ); // === 'person'
    */
@@ -707,11 +707,11 @@
    *     var inflection = require( 'inflection' );
    *
    *     inflection.inflect( 'people' 1 ); // === 'person'
-   *     inflection.inflect( 'octopi' 1 ); // === 'octopus'
+   *     inflection.inflect( 'octopuses' 1 ); // === 'octopus'
    *     inflection.inflect( 'Hats' 1 ); // === 'Hat'
    *     inflection.inflect( 'guys', 1 , 'person' ); // === 'person'
    *     inflection.inflect( 'person', 2 ); // === 'people'
-   *     inflection.inflect( 'octopus', 2 ); // === 'octopi'
+   *     inflection.inflect( 'octopus', 2 ); // === 'octopuses'
    *     inflection.inflect( 'Hat', 2 ); // === 'Hats'
    *     inflection.inflect( 'person', 2, null, 'guys' ); // === 'guys'
    */

--- a/test/inflection.js
+++ b/test/inflection.js
@@ -21,7 +21,7 @@ describe( 'test .pluralize', function (){
     inflection.pluralize( 'women' ).should.equal( 'women' );
     inflection.pluralize( 'woman' ).should.equal( 'women' );
     inflection.pluralize( 'person' ).should.equal( 'people' );
-    inflection.pluralize( 'octopus' ).should.equal( 'octopi' );
+    inflection.pluralize( 'octopus' ).should.equal( 'octopuses' );
     inflection.pluralize( 'human' ).should.equal( 'humans' );
     inflection.pluralize( 'aircraft' ).should.equal( 'aircraft' );
     inflection.pluralize( 'luck' ).should.equal( 'luck' );
@@ -71,7 +71,7 @@ describe( 'test .singularize', function (){
     inflection.singularize( 'people' ).should.equal( 'person' );
     inflection.singularize( 'movies' ).should.equal( 'movie' );
     inflection.singularize( 'queries' ).should.equal( 'query' );
-    inflection.singularize( 'octopi' ).should.equal( 'octopus' );
+    inflection.singularize( 'octopuses' ).should.equal( 'octopus' );
     inflection.singularize( 'Hats' ).should.equal( 'Hat' );
     inflection.singularize( 'lives' ).should.equal( 'life' );
     inflection.singularize( 'baths' ).should.equal( 'bath' );
@@ -111,7 +111,7 @@ describe( 'test .inflect', function (){
     inflection.inflect( 'people', 0 ).should.equal( 'people' );
     inflection.inflect( 'men', 0 ).should.equal( 'men' );
     inflection.inflect( 'person', 0 ).should.equal( 'people' );
-    inflection.inflect( 'octopus', 0 ).should.equal( 'octopi' );
+    inflection.inflect( 'octopus', 0 ).should.equal( 'octopuses' );
     inflection.inflect( 'Hat', 0 ).should.equal( 'Hats' );
     inflection.inflect( 'data', 0 ).should.equal( 'data' );
     inflection.inflect( 'meta', 0 ).should.equal( 'meta' );
@@ -120,7 +120,7 @@ describe( 'test .inflect', function (){
     inflection.inflect( 'people', 2 ).should.equal( 'people' );
     inflection.inflect( 'men', 2 ).should.equal( 'men' );
     inflection.inflect( 'person', 2 ).should.equal( 'people' );
-    inflection.inflect( 'octopus', 2 ).should.equal( 'octopi' );
+    inflection.inflect( 'octopus', 2 ).should.equal( 'octopuses' );
     inflection.inflect( 'Hat', 2 ).should.equal( 'Hats' );
     inflection.inflect( 'data', 2 ).should.equal( 'data' );
     inflection.inflect( 'meta', 2 ).should.equal( 'meta' );
@@ -134,7 +134,7 @@ describe( 'test .inflect', function (){
     inflection.inflect( 'people', 1 ).should.equal( 'person' );
     inflection.inflect( 'movies', 1 ).should.equal( 'movie' );
     inflection.inflect( 'queries', 1 ).should.equal( 'query' );
-    inflection.inflect( 'octopi', 1 ).should.equal( 'octopus' );
+    inflection.inflect( 'octopuses', 1 ).should.equal( 'octopus' );
     inflection.inflect( 'Hats', 1 ).should.equal( 'Hat' );
     inflection.inflect( 'data', 1 ).should.equal( 'datum' );
     inflection.inflect( 'meta', 1 ).should.equal( 'metum' );


### PR DESCRIPTION
Fixes #80 
> Octopus should be pluralized as octopuses.
https://en.wiktionary.org/wiki/octopus
`Octopi` is a hypercorrection, from an incorrect assumption that the word is Latin in origin. It's currently an accepted pluralization, however `octopuses` is more common and more correct.
Since octopus is actually from Greek, the correct Greek pluralization would be `octopodes`. But nobody really says that. So it should be `octopuses`.
>
> Since the regex also includes `virus`, it should be noted that `viruses` is also more correct than `viri` (it's listed first on [https://en.wiktionary.org/wiki/virus](wikitionary), with `viri` listed as a "proscribed" pluralization, which means that nobody uses it except for prescriptivists.)