### PR TITLE
fix: Modified inflect() method to allow floats

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -699,7 +699,7 @@
 
 
   /**
-   * This function will pluralize or singularlize a String appropriately based on an integer value
+   * This function will pluralize or singularlize a String appropriately based on a number value
    * @public
    * @function
    * @param {String} str The subject string.
@@ -715,20 +715,21 @@
    *     inflection.inflect( 'octopuses' 1 ); // === 'octopus'
    *     inflection.inflect( 'Hats' 1 ); // === 'Hat'
    *     inflection.inflect( 'guys', 1 , 'person' ); // === 'person'
+   *     inflection.inflect( 'inches', 1.5 ); // === 'inches'
    *     inflection.inflect( 'person', 2 ); // === 'people'
    *     inflection.inflect( 'octopus', 2 ); // === 'octopuses'
    *     inflection.inflect( 'Hat', 2 ); // === 'Hats'
    *     inflection.inflect( 'person', 2, null, 'guys' ); // === 'guys'
    */
     inflect : function ( str, count, singular, plural ){
-      count = parseInt( count, 10 );
+      count = parseFloat( count, 10 );
 
       if( isNaN( count )) return str;
 
-      if( count === 0 || count > 1 ){
-        return inflector._apply_rules( str, plural_rules, uncountable_words, plural );
-      }else{
+      if( count === 1 ){
         return inflector._apply_rules( str, singular_rules, uncountable_words, singular );
+      }else{
+        return inflector._apply_rules( str, plural_rules, uncountable_words, plural );
       }
     },
 

--- a/test/inflection.js
+++ b/test/inflection.js
@@ -150,6 +150,9 @@ describe( 'test .inflect', function (){
     inflection.inflect( 'original', 'not a number' ).should.equal( 'original' );
     inflection.inflect( 'drive', 1 ).should.equal( 'drive' );
     inflection.inflect( 'drives', 1 ).should.equal( 'drive' );
+    // decimal numbers should use plural state
+    inflection.inflect( 'inches', 1.5 ).should.equal( 'inches' );
+    inflection.inflect( 'inches', 1.0 ).should.equal( 'inch' );
   });
 });
 


### PR DESCRIPTION
If you give the `inflect()` function a float number such as `1.5` (or really any number between 1 < n <= 2) the string should be pluralized. Due to the `parseInt()`, however, the string is left singular. This fix aims to solve that issue by allowing floats and evaluating the only case where singular is used: `count=1;`.

Example:
`inflect( 'inches', 1) // 'inch'`
`inflect( 'inches', 1.5) // 'inches'`