### PR TITLE
fix: add uncountable words and fix 'seperate' typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -339,7 +339,7 @@ This function adds foreign key support to every String object.
 > low_first_letter
 
     type: Boolean
-    desc: Default is to seperate id with an underbar at the end of the class name, you can pass true to skip it.(optional)
+    desc: Default is to separate id with an underbar at the end of the class name, you can pass true to skip it.(optional)
 
 #### Example code
 ```js

--- a/src/inflection.ts
+++ b/src/inflection.ts
@@ -23,12 +23,14 @@ const uncountableWords = [
   'aircraft',
   'alcohol',
   'anger',
+  'any',
   'applause',
   'arithmetic',
   // 'art',
   'assistance',
   'athletics',
   // 'attention',
+  'aws',
 
   'bacon',
   'baggage',
@@ -184,6 +186,7 @@ const uncountableWords = [
   'mayonnaise',
   'measles',
   // 'meat',
+  'media',
   // 'metal',
   'methane',
   'milk',
@@ -213,6 +216,7 @@ const uncountableWords = [
   // 'permission',
   'physics',
   'poetry',
+  'police',
   'pollution',
   'poverty',
   // 'power',
@@ -917,7 +921,7 @@ export function classify(str: string) {
 /**
    * This function adds foreign key support to every String object.
    * @param str The subject string.
-   * @param dropIdUbar Default is to seperate id with an underbar at the end of the class name,
+   * @param dropIdUbar Default is to separate id with an underbar at the end of the class name,
                                  you can pass true to skip it.(optional)
    * @returns Underscored plural nouns become the camel cased singular form.
    * @example

--- a/test/inflection.test.ts
+++ b/test/inflection.test.ts
@@ -47,6 +47,10 @@ describe('test .pluralize', function () {
     expect(inflection.pluralize('grammar')).toEqual('grammars');
     expect(inflection.pluralize('drive')).toEqual('drives');
     expect(inflection.pluralize('database')).toEqual('databases');
+    expect(inflection.pluralize('any')).toEqual('any');
+    expect(inflection.pluralize('aws')).toEqual('aws');
+    expect(inflection.pluralize('media')).toEqual('media');
+    expect(inflection.pluralize('police')).toEqual('police');
   });
 });
 
@@ -97,6 +101,10 @@ describe('test .singularize', function () {
     expect(inflection.singularize('grammars')).toEqual('grammar');
     expect(inflection.singularize('drives')).toEqual('drive');
     expect(inflection.singularize('databases')).toEqual('database');
+    expect(inflection.singularize('any')).toEqual('any');
+    expect(inflection.singularize('aws')).toEqual('aws');
+    expect(inflection.singularize('media')).toEqual('media');
+    expect(inflection.singularize('police')).toEqual('police');
   });
 });
 


### PR DESCRIPTION
Adds `any`, `aws`, `media`, and `police` to the uncountable words list so they are no longer mis-pluralized or mis-singularized (`anies`, `aw`, `medum`, `polouse`). Also corrects the `seperate` spelling in the `foreignKey` JSDoc and Readme.

Fixes #65, #76, #111, #112
Refs #113