### PR TITLE
fix: pluralize nucleus/nuclei correctly

### DIFF
--- a/src/inflection.ts
+++ b/src/inflection.ts
@@ -376,6 +376,8 @@ const regex = {
     whereases: new RegExp('^(whereas)es$', 'gi'),
     criteria: new RegExp('^(criteri)a$', 'gi'),
     genera: new RegExp('^genera$', 'gi'),
+    nuclei: new RegExp('^(nucle)i$', 'gi'),
+    nucleuses: new RegExp('^(nucle)uses$', 'gi'),
     ss: new RegExp('ss$', 'gi'),
     s: new RegExp('s$', 'gi'),
   },
@@ -409,6 +411,7 @@ const regex = {
     whereas: new RegExp('^(whereas)$', 'gi'),
     criterion: new RegExp('^(criteri)on$', 'gi'),
     genus: new RegExp('^genus$', 'gi'),
+    nucleus: new RegExp('^(nucle)us$', 'gi'),
     s: new RegExp('s$', 'gi'),
     common: new RegExp('$', 'gi'),
   },
@@ -448,6 +451,8 @@ const pluralRules: [RegExp, string?][] = [
   [regex.plural.whereases],
   [regex.plural.criteria],
   [regex.plural.genera],
+  [regex.plural.nuclei],
+  [regex.plural.nucleuses],
 
   // original rule
   [regex.singular.man, '$1en'],
@@ -478,6 +483,7 @@ const pluralRules: [RegExp, string?][] = [
   [regex.singular.whereas, '$1es'],
   [regex.singular.criterion, '$1a'],
   [regex.singular.genus, 'genera'],
+  [regex.singular.nucleus, '$1i'],
 
   [regex.singular.s, 's'],
   [regex.singular.common, 's'],
@@ -515,6 +521,7 @@ const singularRules: [RegExp, string?][] = [
   [regex.singular.whereas],
   [regex.singular.criterion],
   [regex.singular.genus],
+  [regex.singular.nucleus],
 
   // original rule
   [regex.plural.men, '$1an'],
@@ -524,6 +531,8 @@ const singularRules: [RegExp, string?][] = [
   [regex.plural.drives, '$1'],
   [regex.plural.genera, 'genus'],
   [regex.plural.criteria, '$1on'],
+  [regex.plural.nuclei, '$1us'],
+  [regex.plural.nucleuses, '$1us'],
   [regex.plural.tia, '$1um'],
   [regex.plural.analyses, '$1$2sis'],
   [regex.plural.hives, '$1ve'],

--- a/test/inflection.test.ts
+++ b/test/inflection.test.ts
@@ -51,6 +51,9 @@ describe('test .pluralize', function () {
     expect(inflection.pluralize('aws')).toEqual('aws');
     expect(inflection.pluralize('media')).toEqual('media');
     expect(inflection.pluralize('police')).toEqual('police');
+    expect(inflection.pluralize('nucleus')).toEqual('nuclei');
+    expect(inflection.pluralize('nuclei')).toEqual('nuclei');
+    expect(inflection.pluralize('nucleuses')).toEqual('nucleuses');
   });
 });
 
@@ -105,6 +108,9 @@ describe('test .singularize', function () {
     expect(inflection.singularize('aws')).toEqual('aws');
     expect(inflection.singularize('media')).toEqual('media');
     expect(inflection.singularize('police')).toEqual('police');
+    expect(inflection.singularize('nuclei')).toEqual('nucleus');
+    expect(inflection.singularize('nucleuses')).toEqual('nucleus');
+    expect(inflection.singularize('nucleus')).toEqual('nucleus');
   });
 });
 


### PR DESCRIPTION
This PR addresses issue #71.

Right now, `pluralize('nucleus')` doesn't actually pluralize, and a few related forms come back mangled:

```js
pluralize('nucleus')     // 'nucleus'   (expected 'nuclei')
pluralize('nuclei')      // 'nucleis'   (expected 'nuclei')
singularize('nuclei')    // 'nuclei'    (expected 'nucleus')
singularize('nucleuses') // 'nucleuse'  (expected 'nucleus')
singularize('nucleus')   // 'nucleu'    (expected 'nucleus')
```

After this PR, each of those returns what you'd expect. `pluralize('nucleuses')` still gives back `'nucleuses'` since it's already plural.

## How

I followed the same shape as the existing `criterion`/`criteria` and `genus`/`genera` rules: three anchored regexes (`^(nucle)us$`, `^(nucle)i$`, `^(nucle)uses$`) added to `regex.singular` and `regex.plural`, with matching skip + replace entries in `pluralRules` and `singularRules`. Because the patterns are anchored to the `nucle` stem, they can't accidentally catch other `-us` or `-i` words.

## Test plan

- [x] `npm test` passes (15 existing tests, plus 6 new assertions covering every case the issue mentioned)