### PR TITLE
fix: singularize 'analyses' to 'analysis' instead of 'analyasis'

### DIFF
--- a/src/inflection.ts
+++ b/src/inflection.ts
@@ -534,7 +534,7 @@ const singularRules: [RegExp, string?][] = [
   [regex.plural.nuclei, '$1us'],
   [regex.plural.nucleuses, '$1us'],
   [regex.plural.tia, '$1um'],
-  [regex.plural.analyses, '$1$2sis'],
+  [regex.plural.analyses, '$1sis'],
   [regex.plural.hives, '$1ve'],
   [regex.plural.curves, '$1'],
   [regex.plural.lrves, '$1f'],

--- a/test/inflection.test.ts
+++ b/test/inflection.test.ts
@@ -111,6 +111,9 @@ describe('test .singularize', function () {
     expect(inflection.singularize('nuclei')).toEqual('nucleus');
     expect(inflection.singularize('nucleuses')).toEqual('nucleus');
     expect(inflection.singularize('nucleus')).toEqual('nucleus');
+    expect(inflection.singularize('analyses')).toEqual('analysis');
+    expect(inflection.singularize('bases')).toEqual('basis');
+    expect(inflection.singularize('diagnoses')).toEqual('diagnosis');
   });
 });
 


### PR DESCRIPTION
`singularize('analyses')` returns `analyasis`, which isn't a word. It should return `analysis`.

`pluralize('analysis')` already gives `analyses`, so singularize is just failing to invert it.

The cause is the replacement string on the `-ses` -> `-sis` rule:

```js
[regex.plural.analyses, '$1$2sis'],
```

The regex is `((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$`. `$1` is the full stem (`analy`, `ba`, `diagno`, ...), and the inner letter groups are `$2` for `(a)`, `$3` for `(b)`, `$4` for `(d)`, and so on. The template uses `$2`, but `$2` is only ever set on the `(a)naly` branch, so it re-appends a stray `a`: `analy` + `a` + `sis` = `analyasis`. For every other word `$2` is empty, which is why `bases`, `diagnoses`, `parentheses`, `prognoses`, `synopses`, `theses` already singularize correctly.

`$1` already contains that `a`, so dropping `$2` fixes `analyses` and leaves the other six untouched:

```js
[regex.plural.analyses, '$1sis'],
```

Added assertions for `analyses`, `bases` and `diagnoses` in the singularize test to lock the family. Full suite passes.
